### PR TITLE
Specify that this version is not compatible with apispec 0.20

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
@@ -25,7 +25,7 @@ requirements:
     - flask >=0.10.1
     - marshmallow >=2.0.0
     - webargs >=0.18.0
-    - apispec >=0.4.1
+    - apispec >=0.4.1,<0.20.0
 
 test:
   imports:


### PR DESCRIPTION
One of the dependencies (apispec) had a backward incompatible update in version 0.20 and this PR ensures that this version of flask-apispec would not pull that incompatible dependency version.